### PR TITLE
Clarify isize/usize pointer-sized

### DIFF
--- a/slides/A1-intro-to-rust.md
+++ b/slides/A1-intro-to-rust.md
@@ -277,11 +277,11 @@ layout: two-cols
 
 | Length        | Signed  | Unsigned |
 |---------------|---------|----------|
-| 8 bit         | `i8`    | `u8`     |
-| 16 bit        | `i16`   | `u16`    |
-| 32 bit        | `i32`   | `u32`    |
-| 64 bit        | `i64`   | `u64`    |
-| 128 bit       | `i128`  | `u128`   |
+| 8 bits        | `i8`    | `u8`     |
+| 16 bits       | `i16`   | `u16`    |
+| 32 bits       | `i32`   | `u32`    |
+| 64 bits       | `i64`   | `u64`    |
+| 128 bits      | `i128`  | `u128`   |
 | pointer-sized | `isize` | `usize`  |
 
 - Rust prefers explicit integer sizes

--- a/slides/A1-intro-to-rust.md
+++ b/slides/A1-intro-to-rust.md
@@ -275,14 +275,14 @@ layout: two-cols
 
 # Integers
 
-| Length                | Signed  | Unsigned |
-|-----------------------|---------|----------|
-| 8 bit                 | `i8`    | `u8`     |
-| 16 bit                | `i16`   | `u16`    |
-| 32 bit                | `i32`   | `u32`    |
-| 64 bit                | `i64`   | `u64`    |
-| 128 bit               | `i128`  | `u128`   |
-| architecture based    | `isize` | `usize`  |
+| Length        | Signed  | Unsigned |
+|---------------|---------|----------|
+| 8 bit         | `i8`    | `u8`     |
+| 16 bit        | `i16`   | `u16`    |
+| 32 bit        | `i32`   | `u32`    |
+| 64 bit        | `i64`   | `u64`    |
+| 128 bit       | `i128`  | `u128`   |
+| pointer-sized | `isize` | `usize`  |
 
 - Rust prefers explicit integer sizes
 - Use `isize` and `usize` sparingly


### PR DESCRIPTION
I think it would be better to specify that `isize` and `usize` are pointer-sized, instead of the more vague statement "architecture based". This patch fixes my concern, if you want to have it.

![image](https://user-images.githubusercontent.com/1263440/223466748-8144801f-f4ee-416e-a750-1767dccd7fd1.png)
