### PR TITLE
implement as_ref for LocalStorageVec is needed for running the test

### DIFF
--- a/exercises/A3/2-local-storage-vec/src/lib.rs
+++ b/exercises/A3/2-local-storage-vec/src/lib.rs
@@ -47,6 +47,15 @@ where
     }
 }
 
+// impl<T, const N: usize> AsRef<[T]> for LocalStorageVec<T, N> {
+//     fn as_ref(&self) -> &[T] {
+//         match self {
+//             LocalStorageVec::Stack { buf, len } => &buf[..*len],
+//             LocalStorageVec::Heap(v) => v.as_ref(),
+//         }
+//     }
+// }
+
 #[cfg(test)]
 mod test {
     use crate::LocalStorageVec;


### PR DESCRIPTION
implement as_ref for LocalStorageVec is needed for running the test