### PR TITLE
Removing as_slice in A3

### DIFF
--- a/exercises/A3/2-local-storage-vec/src/lib.rs
+++ b/exercises/A3/2-local-storage-vec/src/lib.rs
@@ -271,12 +271,12 @@ mod test {
     // #[test]
     // fn it_derefs() {
     //     use std::ops::{Deref, DerefMut};
-    //     let vec: LocalStorageVec<_, 128> = LocalStorageVec::from([0; 128].as_slice());
+    //     let vec: LocalStorageVec<_, 128> = LocalStorageVec::from([0; 128]);
     //     // `chunks` is a method that's defined for slices `[T]`, that we can use thanks to `Deref`
     //     let chunks = vec.chunks(4);
     //     let slice: &[_] = vec.deref();
     //
-    //     let mut vec: LocalStorageVec<_, 128> = LocalStorageVec::from([0; 128].as_slice());
+    //     let mut vec: LocalStorageVec<_, 128> = LocalStorageVec::from([0; 128]);
     //     let chunks = vec.chunks_mut(4);
     //     let slice: &mut [_] = vec.deref_mut();
     // }


### PR DESCRIPTION
Hi,

In the exercises for A3 `.as_slice()` is used in `LocalStorageVec::from` (last test case).

It is however nowhere mentioned to implement `From<&[T; N]>` for `LocalStorageVec`.

Implementations at the end of the exercises in A3:
* `From<[T; N]>`
* `From<Vec<T>>`

This PR removes the use of `as_slice`, so the last section can be more easily finished.

Kind regards,

SamClercky

cc @rubdos 