### PR TITLE
Stack heap diagram fixes

### DIFF
--- a/slides/A1-intro-to-rust.md
+++ b/slides/A1-intro-to-rust.md
@@ -856,7 +856,7 @@ There are two mechanisms at play here, generally known as the stack and the heap
         </div>
     </div>
     <div>
-        <div class="relative top-12 left-26">🠔 Stack pointer</div>
+        <div class="relative top-12 left-6">← Stack pointer</div>
     </div>
 </div>
 
@@ -895,7 +895,7 @@ There are two mechanisms at play here, generally known as the stack and the heap
         </div>
     </div>
     <div>
-        <div class="relative top-19 left-26">🠔 Stack pointer</div>
+        <div class="relative top-19 left-6">← Stack pointer</div>
         <div class="relative pl-27 top-20">
             A stack frame is allocated for every function call. It contains exactly
             enough space for all local variables, arguments and stores where the
@@ -927,13 +927,13 @@ There are two mechanisms at play here, generally known as the stack and the heap
         </div>
         <div class="bg-yellow-100 rounded-b-md h-130px flex flex-col">
             <div class="text-gray-500 p-2">Heap</div>
-            <div class="bg-yellow-300 mb-3 h-5">Allocated</div>
+            <div class="bg-yellow-300 mb-3 h-7">Allocated</div>
             <div class="bg-yellow-300 mb-1 h-9"></div>
             <div class="bg-yellow-300 h-4"></div>
         </div>
     </div>
     <div>
-        <div class="relative top-12 left-26">🠔 Stack pointer</div>
+        <div class="relative top-12 left-6">← Stack pointer</div>
         <div class="relative pl-27 top-13">
             Once a function call ends we just move back up, and everything below is
             available as free memory once more.

--- a/slides/A1-intro-to-rust.md
+++ b/slides/A1-intro-to-rust.md
@@ -850,7 +850,7 @@ There are two mechanisms at play here, generally known as the stack and the heap
         </div>
         <div class="bg-yellow-100 rounded-b-md h-130px flex flex-col">
             <div class="text-gray-500 p-2">Heap</div>
-            <div class="bg-yellow-300 mb-3 h-5">Allocated</div>
+            <div class="bg-yellow-300 mb-3 h-7">Allocated</div>
             <div class="bg-yellow-300 mb-1 h-9"></div>
             <div class="bg-yellow-300 h-4"></div>
         </div>
@@ -889,7 +889,7 @@ There are two mechanisms at play here, generally known as the stack and the heap
         </div>
         <div class="bg-yellow-100 rounded-b-md h-130px flex flex-col">
             <div class="text-gray-500 p-2">Heap</div>
-            <div class="bg-yellow-300 mb-3 h-5">Allocated</div>
+            <div class="bg-yellow-300 mb-3 h-7">Allocated</div>
             <div class="bg-yellow-300 mb-1 h-9"></div>
             <div class="bg-yellow-300 h-4"></div>
         </div>

--- a/slides/A1-intro-to-rust.md
+++ b/slides/A1-intro-to-rust.md
@@ -896,7 +896,7 @@ There are two mechanisms at play here, generally known as the stack and the heap
     </div>
     <div>
         <div class="relative top-19 left-6">← Stack pointer</div>
-        <div class="relative pl-27 top-20">
+        <div class="relative pl-7 top-20">
             A stack frame is allocated for every function call. It contains exactly
             enough space for all local variables, arguments and stores where the
             previous stack frame starts.
@@ -934,7 +934,7 @@ There are two mechanisms at play here, generally known as the stack and the heap
     </div>
     <div>
         <div class="relative top-12 left-6">← Stack pointer</div>
-        <div class="relative pl-27 top-13">
+        <div class="relative pl-7 top-13">
             Once a function call ends we just move back up, and everything below is
             available as free memory once more.
         </div>

--- a/slides/A1-intro-to-rust.md
+++ b/slides/A1-intro-to-rust.md
@@ -878,7 +878,7 @@ pointer (to the current stack frame) is decreased.
 There are two mechanisms at play here, generally known as the stack and the heap
 
 <div class="grid grid-cols-2">
-    <div class="flex flex-col rounded-md p-1 bg-teal-100 text-center w-md h-250px">
+    <div class="flex flex-col rounded-md p-1 bg-teal-100 text-center w-md h-350px">
         <div class="bg-red-100 rounded-t-md flex flex-col">
             <div class="bg-red-200 rounded-t-md p-1 border-red-500 border">Frame 1</div>
             <div class="bg-red-200 p-1 border-red-500 border border-t-0">Frame 2</div>

--- a/slides/styles/code.css
+++ b/slides/styles/code.css
@@ -15,3 +15,7 @@ div[layout="two-cols"] div.col-right {
   padding-left:10px;
    padding-top: 53px;
 }
+
+.bg-red-200, .bg-yellow-300 {
+    color: black;
+}


### PR DESCRIPTION
After:

![image](https://github.com/tweedegolf/101-rs/assets/76812/671f14c5-d4c4-463f-8439-cb7338001958)

Before:

![image](https://github.com/tweedegolf/101-rs/assets/76812/97e3f06b-a805-441c-9bf9-e3d8c94637b0)

Included here are these changes. Let me know if you'd like me to split them out into separate PRs:

* Set the font colour so that 'Frame 1' etc. are visible in dark mode
* Expand the 'Allocated' box to fit the text
* Increase the height of the diagram when more memory is used
* Replace the arrow for the stack pointer - the arrow that was used before was not visible on my machine (Ubuntu 22.04)
* Move the stack pointer arrow closer to the diagram
