### PR TITLE
Fix missing end tag in slide

### DIFF
--- a/content/mods/A-foundations/topics/composite-types/slides.md
+++ b/content/mods/A-foundations/topics/composite-types/slides.md
@@ -123,7 +123,7 @@ enum IpAddressType {
   * a numeric value (`isize` by default, can be changed by using `#[repr(numeric_type)]`) used to determine the variant that the enumeration holds 
   * one cannot rely on the fact that the discriminant is an `isize`, the compiler may always decide to optimize it
 
-<v-click>
+</v-click>
 
 <v-click>
 


### PR DESCRIPTION
To prevent an `Internal server error: Element is missing end tag.` error when presenting the slides.